### PR TITLE
Fixing Opera Browser version

### DIFF
--- a/src/Ikimea/Browser/Browser.php
+++ b/src/Ikimea/Browser/Browser.php
@@ -528,7 +528,7 @@ class Browser {
         }
         else if( stripos($this->_agent,'opera') !== false ) {
             $resultant = stristr($this->_agent, 'opera');
-            if( preg_match('/Version\/(10.*)$/',$resultant,$matches) ) {
+            if( preg_match('/Version\/([0-9]*.[0-9]*)$/',$resultant,$matches) ) {
                 $this->setVersion($matches[1]);
             }
             else if( preg_match('/\//',$resultant) ) {


### PR DESCRIPTION
According to:
http://www.useragentstring.com/pages/Opera/
If Opera browser's engine is above 9.8, version is behind "Version" tag.
That commit fix getting version from that tag.
