### PR TITLE
Fix the Windows Phone recognization

### DIFF
--- a/lib/Ikimea/Browser/Browser.php
+++ b/lib/Ikimea/Browser/Browser.php
@@ -1102,9 +1102,7 @@ class Browser
      */
     protected function checkPlatform()
     {
-        if (stripos($this->_agent, 'windows') !== false) {
-            $this->_platform = self::PLATFORM_WINDOWS;
-        } elseif (stripos($this->_agent, 'iPad') !== false) {
+        if (stripos($this->_agent, 'iPad') !== false) {
             $this->_platform = self::PLATFORM_IPAD;
             $this->setMobile(true);
         } elseif (stripos($this->_agent, 'iPod') !== false) {
@@ -1129,6 +1127,8 @@ class Browser
         } elseif (stripos($this->_agent, 'Windows Phone') !== false) {
             $this->_platform = self::PLATFORM_WINDOWSPHONE;
             $this->setMobile(true);
+        } elseif (stripos($this->_agent, 'windows') !== false) {
+            $this->_platform = self::PLATFORM_WINDOWS;
         } elseif (stripos($this->_agent, 'FreeBSD') !== false) {
             $this->_platform = self::PLATFORM_FREEBSD;
         } elseif (stripos($this->_agent, 'OpenBSD') !== false) {


### PR DESCRIPTION
With a Windows Phone user-agent, the `windows` string is recognized before `Windows Phone`, so that's a bug.
Here is a quick fix :smile_cat: 