### PR TITLE
Fix: New android user agents do not fall into browser opera

### DIFF
--- a/lib/Ikimea/Browser/Browser.php
+++ b/lib/Ikimea/Browser/Browser.php
@@ -657,6 +657,11 @@ class Browser
             return true;
         } elseif (stripos($this->_agent, 'OPR') !== false) {
             $aresult = explode('/', stristr($this->_agent, 'OPR'));
+
+            if (empty($aresult[1])) {
+                return false;
+            }
+            
             $aversion = explode(' ', $aresult[1]);
             $this->setVersion($aversion[0]);
             $this->setBrowser(self::BROWSER_OPERA_CHROMIUM);


### PR DESCRIPTION
Some new users of Android agents were confused with the browser opera, because it contains the acronym 'OPR'.